### PR TITLE
Added support for forloops without an init and/or without a step

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
         "build:watch": "tsc --watch",
         "lint": "eslint .",
         "format": "prettier --write .",
-        "sandbox": "cross-env DEBUG=\"*\" npx clava out/src/sandbox.js -- clang in/sandbox",
-        "sandbox:watch": "cross-env DEBUG=\"*\" npx clava out/src/sandbox.js -w out/src -w in/sandbox -- clang in/sandbox",
+        "sandbox": "cross-env DEBUG=\"*\" npx clava dist/sandbox.js -- clang in/sandbox",
+        "sandbox:watch": "cross-env DEBUG=\"*\" npx clava dist/sandbox.js -w dist/ -w in/sandbox -- clang in/sandbox",
         "docs": "typedoc --out docs"
     },
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@specs-feup/clava-flow",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Control-flow, Data-flow, static-call, and other graphs for Clava.",
     "type": "module",
     "files": [

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -11,7 +11,7 @@ const graph = Graph.create()
     .apply(new ClavaScgGenerator(Query.root() as Program));
 
 const formatter = new ClavaFlowDotFormatter();
-graph.toFile(formatter, "out/graph.dot");
+graph.toFile(formatter, "dist/graph.dot");
 
 Query.search(Vardecl, v => v.name === "unique").get().forEach(v => {
     console.log(v.name, v.getAncestor("function")?.code, "\n==================\n\n\n");

--- a/src/transformation/ClavaCfgGenerator.ts
+++ b/src/transformation/ClavaCfgGenerator.ts
@@ -613,7 +613,7 @@ export default class ClavaCfgGenerator
         ctx.addConditionalEdge(conditionNode, body.head!, true);
 
         const continueTarget =
-            $jp.kind === "for" && step !== undefined && step!.head !== undefined ? step!.head : conditionNode;
+            $jp.kind === "for" && step !== undefined && step.head !== undefined ? step.head : conditionNode;
 
         for (const bodyTailNode of body.normalTail) {
             ctx.addCfgEdge(bodyTailNode, continueTarget);
@@ -625,14 +625,14 @@ export default class ClavaCfgGenerator
 
         if ($jp.kind === "for") {
             if (step !== undefined) {
-                for (const stepTailNode of step!.normalTail) {
+                for (const stepTailNode of step.normalTail) {
                     ctx.addCfgEdge(stepTailNode, conditionNode);
                 }
 
             }
 
             if (init !== undefined) {
-                for (const initTailNode of init!.normalTail) {
+                for (const initTailNode of init.normalTail) {
                     ctx.addCfgEdge(initTailNode, conditionNode);
                 }
             }
@@ -641,8 +641,8 @@ export default class ClavaCfgGenerator
         let head: ClavaControlFlowNode.Class;
         if ($jp.kind === "dowhile") {
             head = body.head!;
-        } else if ($jp.kind === "for" && init !== undefined && init!.head !== undefined) {
-            head = init!.head;
+        } else if ($jp.kind === "for" && init !== undefined && init.head !== undefined) {
+            head = init.head;
         } else {
             head = conditionNode;
         }

--- a/src/transformation/ClavaCfgGenerator.ts
+++ b/src/transformation/ClavaCfgGenerator.ts
@@ -332,8 +332,7 @@ class GeneratorContext {
 }
 
 export default class ClavaCfgGenerator
-    implements Graph.Transformation<BaseGraph.Class, ClavaFlowGraph.Class>
-{
+    implements Graph.Transformation<BaseGraph.Class, ClavaFlowGraph.Class> {
     #jps: (Program | FileJp | FunctionJp)[];
 
     constructor(...jps: (Program | FileJp | FunctionJp)[]) {
@@ -580,7 +579,7 @@ export default class ClavaCfgGenerator
         let step: SubGraph | undefined;
         let uninitConditionNode: ControlFlowNode.Class | undefined;
 
-        if ($jp.kind === "for") {
+        if ($jp.kind === "for" && $jp.init !== undefined) {
             init = this.#processJp($jp.init, ctx);
         }
 
@@ -598,7 +597,7 @@ export default class ClavaCfgGenerator
             // Only scenario where conditionNode is not defined
             uninitConditionNode = ctx.addCfgNode(new DoWhileNode.Builder($jp));
         } else if ($jp.kind === "for") {
-            step = this.#processJp($jp.step, ctx);
+            if ($jp.step !== undefined) step = this.#processJp($jp.step, ctx);
             // TODO add init and step to ForNode
             uninitConditionNode!.init(new ForNode.Builder($jp));
         } else if ($jp.kind === "foreach") {
@@ -614,27 +613,35 @@ export default class ClavaCfgGenerator
         ctx.addConditionalEdge(conditionNode, body.head!, true);
 
         const continueTarget =
-            $jp.kind === "for" && step!.head !== undefined ? step!.head : conditionNode;
+            $jp.kind === "for" && step !== undefined && step!.head !== undefined ? step!.head : conditionNode;
+
         for (const bodyTailNode of body.normalTail) {
             ctx.addCfgEdge(bodyTailNode, continueTarget);
         }
+
         for (const continueNode of continues) {
             ctx.connectOutwardsJump(continueNode, continueTarget);
         }
+
         if ($jp.kind === "for") {
-            for (const stepTailNode of step!.normalTail) {
-                ctx.addCfgEdge(stepTailNode, conditionNode);
+            if (step !== undefined) {
+                for (const stepTailNode of step!.normalTail) {
+                    ctx.addCfgEdge(stepTailNode, conditionNode);
+                }
+
             }
 
-            for (const initTailNode of init!.normalTail) {
-                ctx.addCfgEdge(initTailNode, conditionNode);
+            if (init !== undefined) {
+                for (const initTailNode of init!.normalTail) {
+                    ctx.addCfgEdge(initTailNode, conditionNode);
+                }
             }
         }
 
         let head: ClavaControlFlowNode.Class;
         if ($jp.kind === "dowhile") {
             head = body.head!;
-        } else if ($jp.kind === "for" && init!.head !== undefined) {
+        } else if ($jp.kind === "for" && init !== undefined && init!.head !== undefined) {
             head = init!.head;
         } else {
             head = conditionNode;

--- a/src/transformation/ClavaCfgGenerator.ts
+++ b/src/transformation/ClavaCfgGenerator.ts
@@ -597,7 +597,9 @@ export default class ClavaCfgGenerator
             // Only scenario where conditionNode is not defined
             uninitConditionNode = ctx.addCfgNode(new DoWhileNode.Builder($jp));
         } else if ($jp.kind === "for") {
-            if ($jp.step !== undefined) step = this.#processJp($jp.step, ctx);
+            if ($jp.step !== undefined) {
+                step = this.#processJp($jp.step, ctx);
+            }
             // TODO add init and step to ForNode
             uninitConditionNode!.init(new ForNode.Builder($jp));
         } else if ($jp.kind === "foreach") {


### PR DESCRIPTION
For loops now do not create the init and the step nodes if they are undefined, avoiding crashes.

This was tested by running the sandbox with the following code:

```c
int main() {
	for (int i = 0; i < 10; i++) {
		int a = 2;
		a++;
	}

	int b = 0;
	for (; b < 10; b++) {
		int c = 3;
		c--;
	}
	
	for (int d = 0; d < 10;) {
		d++;
	}

	int e = 6;
}
```

and manually analyzing the output
![sandbox](https://github.com/user-attachments/assets/b346a0f9-05d8-4448-8f94-c7ea504a9ff5)

which is by no means an appropriate testing methodology... but it seems to work, for now.
For loops without conditions still crash, I'll fix that in another branch in the future
