### PR TITLE
Added basic support for in-line assembly nodes 

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "homepage": "https://github.com/specs-feup/clava-flow#readme",
     "dependencies": {
-        "@specs-feup/clava": "^3.0.5",
+        "@specs-feup/clava": "^3.0.32",
         "@specs-feup/lara": "^3.0.4",
         "@specs-feup/flow": "^1.0.3"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@specs-feup/clava-flow",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Control-flow, Data-flow, static-call, and other graphs for Clava.",
     "type": "module",
     "files": [

--- a/src/cfg/node/AsmStatementNode.ts
+++ b/src/cfg/node/AsmStatementNode.ts
@@ -1,6 +1,6 @@
 import ClavaControlFlowNode from "@specs-feup/clava-flow/ClavaControlFlowNode";
 import ClavaNode from "@specs-feup/clava-flow/ClavaNode";
-import { Expression, Statement } from "@specs-feup/clava/api/Joinpoints.js";
+import { AsmStmt } from "@specs-feup/clava/api/Joinpoints.js";
 import ControlFlowNode from "@specs-feup/flow/flow/ControlFlowNode";
 import Node from "@specs-feup/flow/graph/Node";
 
@@ -12,7 +12,7 @@ namespace AsmStatementNode {
         D extends Data = Data,
         S extends ScratchData = ScratchData,
     > extends ClavaControlFlowNode.Class<D, S> {
-        override get jp(): Statement {
+        override get jp(): AsmStmt {
             return this.scratchData[ClavaNode.TAG].jp;
         }
     }
@@ -26,10 +26,10 @@ namespace AsmStatementNode {
                 ControlFlowNode.ScratchData
             >
     {
-        #jp: Statement;
+        #jp: AsmStmt;
         #clavaNodeBuilder: ClavaNode.Builder;
 
-        constructor(jp: Statement) {
+        constructor(jp: AsmStmt) {
             this.#jp = jp;
             this.#clavaNodeBuilder = new ClavaNode.Builder(this.#jp);
         }
@@ -61,7 +61,7 @@ namespace AsmStatementNode {
         (sData) => {
             return (
                 ClavaControlFlowNode.TypeGuard.isScratchDataCompatible(sData) &&
-                sData[ClavaNode.TAG].jp instanceof Statement
+                sData[ClavaNode.TAG].jp instanceof AsmStmt
             );
         },
     );
@@ -74,7 +74,7 @@ namespace AsmStatementNode {
 
     export interface ScratchData extends ClavaControlFlowNode.ScratchData {
         [ClavaNode.TAG]: {
-            jp: Statement;
+            jp: AsmStmt;
         };
     }
 }

--- a/src/cfg/node/AsmStatementNode.ts
+++ b/src/cfg/node/AsmStatementNode.ts
@@ -1,0 +1,82 @@
+import ClavaControlFlowNode from "@specs-feup/clava-flow/ClavaControlFlowNode";
+import ClavaNode from "@specs-feup/clava-flow/ClavaNode";
+import { Expression, Statement } from "@specs-feup/clava/api/Joinpoints.js";
+import ControlFlowNode from "@specs-feup/flow/flow/ControlFlowNode";
+import Node from "@specs-feup/flow/graph/Node";
+
+namespace AsmStatementNode {
+    export const TAG = "__clava_flow__asm_statement_node";
+    export const VERSION = "1";
+
+    export class Class<
+        D extends Data = Data,
+        S extends ScratchData = ScratchData,
+    > extends ClavaControlFlowNode.Class<D, S> {
+        override get jp(): Statement {
+            return this.scratchData[ClavaNode.TAG].jp;
+        }
+    }
+
+    export class Builder
+        implements
+            Node.Builder<
+                Data,
+                ScratchData,
+                ControlFlowNode.Data,
+                ControlFlowNode.ScratchData
+            >
+    {
+        #jp: Statement;
+        #clavaNodeBuilder: ClavaNode.Builder;
+
+        constructor(jp: Statement) {
+            this.#jp = jp;
+            this.#clavaNodeBuilder = new ClavaNode.Builder(this.#jp);
+        }
+
+        buildData(data: ControlFlowNode.Data): Data {
+            return {
+                ...data,
+                ...this.#clavaNodeBuilder.buildData(data),
+                [TAG]: {
+                    version: VERSION,
+                },
+            };
+        }
+
+        buildScratchData(scratchData: ControlFlowNode.ScratchData): ScratchData {
+            return {
+                ...scratchData,
+                ...this.#clavaNodeBuilder.buildScratchData(scratchData),
+                [ClavaNode.TAG]: {
+                    jp: this.#jp,
+                },
+            };
+        }
+    }
+
+    export const TypeGuard = Node.TagTypeGuard<Data, ScratchData>(
+        TAG,
+        VERSION,
+        (sData) => {
+            return (
+                ClavaControlFlowNode.TypeGuard.isScratchDataCompatible(sData) &&
+                sData[ClavaNode.TAG].jp instanceof Statement
+            );
+        },
+    );
+
+    export interface Data extends ClavaControlFlowNode.Data {
+        [TAG]: {
+            version: typeof VERSION;
+        };
+    }
+
+    export interface ScratchData extends ClavaControlFlowNode.ScratchData {
+        [ClavaNode.TAG]: {
+            jp: Statement;
+        };
+    }
+}
+
+export default AsmStatementNode;

--- a/src/dot/ClavaFlowDotFormatter.ts
+++ b/src/dot/ClavaFlowDotFormatter.ts
@@ -23,9 +23,9 @@ import { ExprStmt, Joinpoint } from "@specs-feup/clava/api/Joinpoints.js";
 import FlowDotFormatter from "@specs-feup/flow/flow/dot/FlowDotFormatter";
 import BaseEdge from "@specs-feup/flow/graph/BaseEdge";
 import BaseNode from "@specs-feup/flow/graph/BaseNode";
-import DefaultDotFormatter from "@specs-feup/flow/graph/dot/DefaultDotFormatter";
 import Edge from "@specs-feup/flow/graph/Edge";
 import Node from "@specs-feup/flow/graph/Node";
+import AsmStatementNode from "../cfg/node/AsmStatementNode.js";
 
 export default class ClavaFlowDotFormatter<
     G extends ClavaFlowGraph.Class = ClavaFlowGraph.Class,
@@ -237,6 +237,12 @@ export default class ClavaFlowDotFormatter<
                         (n.jp.children[3] as ExprStmt).expr.code,
                     ),
                     ClavaFlowDotFormatter.renderSymbol("; ...)"),
+                );
+            }),
+            Node.Case(AsmStatementNode, (n) => {
+                result.label = ClavaFlowDotFormatter.renderNodeLabel(
+                    n.jp,
+                    ClavaFlowDotFormatter.renderKeyword("inline assembly"),
                 );
             }),
             Node.Case(ClavaControlFlowNode, (n) => {

--- a/src/transformation/ClavaCfgGenerator.ts
+++ b/src/transformation/ClavaCfgGenerator.ts
@@ -38,7 +38,6 @@ import {
     Program,
     ReturnStmt,
     Scope,
-    Statement,
     Switch,
     Vardecl,
     WrapperStmt,

--- a/src/transformation/ClavaCfgGenerator.ts
+++ b/src/transformation/ClavaCfgGenerator.ts
@@ -42,6 +42,7 @@ import {
     Switch,
     Vardecl,
     WrapperStmt,
+    AsmStmt
 } from "@specs-feup/clava/api/Joinpoints.js";
 import LaraFlowError from "@specs-feup/flow/error/LaraFlowError";
 import ControlFlowEdge from "@specs-feup/flow/flow/ControlFlowEdge";
@@ -518,7 +519,7 @@ export default class ClavaCfgGenerator
             return this.#processLabel(jp.decl, ctx);
         } else if (jp instanceof GotoStmt) {
             return this.#processGoto(jp, ctx);
-        } else if (jp instanceof Statement && jp.type === undefined && (jp.code.startsWith("__asm__ ") || jp.code.startsWith("__asm__("))) {
+        } else if (jp instanceof AsmStmt) {
             const node = ctx.addCfgNode(new AsmStatementNode.Builder(jp));
             return SubGraph.fromSingle(node);
         }

--- a/src/transformation/ClavaCfgGenerator.ts
+++ b/src/transformation/ClavaCfgGenerator.ts
@@ -38,6 +38,7 @@ import {
     Program,
     ReturnStmt,
     Scope,
+    Statement,
     Switch,
     Vardecl,
     WrapperStmt,
@@ -51,6 +52,7 @@ import BaseGraph from "@specs-feup/flow/graph/BaseGraph";
 import Graph from "@specs-feup/flow/graph/Graph";
 import Node from "@specs-feup/flow/graph/Node";
 import Query from "@specs-feup/lara/api/weaver/Query.js";
+import AsmStatementNode from "../cfg/node/AsmStatementNode.js";
 
 class SubGraph {
     head: ClavaControlFlowNode.Class | undefined;
@@ -516,6 +518,9 @@ export default class ClavaCfgGenerator
             return this.#processLabel(jp.decl, ctx);
         } else if (jp instanceof GotoStmt) {
             return this.#processGoto(jp, ctx);
+        } else if (jp instanceof Statement && jp.type === undefined && (jp.code.startsWith("__asm__ ") || jp.code.startsWith("__asm__("))) {
+            const node = ctx.addCfgNode(new AsmStatementNode.Builder(jp));
+            return SubGraph.fromSingle(node);
         }
 
         throw new Error("Unsupported joinpoint type " + jp.joinPointType);


### PR DESCRIPTION
Added an AsmStatementNode that will be added to the CFG Instead of crashing due to unsupported node type. Currently, the node does not provide any useful insights as to what the assembly is actually doing, and will not detect any jumps performed in it.
The user should be aware of these limitations and, if needed, add their own pass that addresses their use-case requirements.

The .dot output does not print the contents of the assembly, since that will most likely clutter the graph due to the length of the code. An example of the output is shown below:

<img width="781" height="523" alt="graphviz(1)" src="https://github.com/user-attachments/assets/694af5b9-e307-4ce0-97e9-fa2a92019808" />

